### PR TITLE
Support panel with scanrate = rows

### DIFF
--- a/DMD_RGB.cpp
+++ b/DMD_RGB.cpp
@@ -33,7 +33,7 @@ DMD_RGB_BASE::DMD_RGB_BASE(byte mux_cnt, uint8_t* mux_list, byte _pin_nOE, byte 
 	OE_polarity = OE_PWM_NEGATIVE;
 
 	// Allocate and initialize matrix buffer:
-	mem_Buffer_Size = panelsWide * panelsHigh * DMD_PIXELS_ACROSS * DMD_PIXELS_DOWN * nPlanes / 2;
+	mem_Buffer_Size = panelsWide * panelsHigh * DMD_PIXELS_ACROSS * DMD_PIXELS_DOWN * nPlanes / (n_Rows < DMD_PIXELS_DOWN ? 2 : 1);
 	col_bytes_cnt = nPlanes;
 	// x3 = 3 bytes holds 4 planes "packed"
 	if (nPlanes == 3) nPlanes = 4;

--- a/DMD_RGB.h
+++ b/DMD_RGB.h
@@ -163,7 +163,7 @@ uint16_t           expand[256];           // 6-to-32 bit converter table
 	volatile uint8_t row, plane;
 	volatile uint8_t* buffptr;
 	uint8_t nPlanes = 4;
-	const uint8_t pol_displ = DMD_PIXELS_DOWN / 2;
+	const uint8_t pol_displ = nRows < DMD_PIXELS_DOWN ? DMD_PIXELS_DOWN / 2 : DMD_PIXELS_DOWN;
 	const uint8_t multiplex = pol_displ / nRows;
 	const uint16_t displ_len = WIDTH * pol_displ * DisplaysHigh;
     uint8_t col_bytes_cnt = nPlanes;


### PR DESCRIPTION
I have a (weird?) 128x64 chinese panel using FM6373 and a RUL5158E for demux. This panel has 64 scanlines as it has 8 demux chips. The library currently assumes that scan lines are always lower than the number of actual led rows on the panel. This PR fixes that. 