### PR TITLE
Add STM32duino (Arduino Core STM32) support for DMD_RGB alongside Roger Clark core

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,11 @@
 # ChangeLog
+## [1.2.12] - 2026-06-01
+ - Add optional STM32duino (Arduino Core STM32) support alongside Roger Clark libmaple core.
+ - Auto-detect core via `ARDUINO_ARCH_STM32` → `DMD_STM32DUINO`; compatibility layer in `DMD_STM32duino.h/cpp`.
+ - STM32duino: `DMD_RGB` on F103/F401/F411 (bit-bang RGB, no RGB DMA; OE PWM via timer shim).
+ - Roger Clark path unchanged (`stm_int.h`, DMA per `DMD_Config.h`).
+ - Example: `examples/STM32duino/dmd_rgb_effects`.
+
 ## [1.2.11] - 2026-05-05
  - Make extended patterns compatible with SPWM classes (STM32)
 

--- a/DMD_Config.h
+++ b/DMD_Config.h
@@ -21,8 +21,8 @@
 //comment line below if you need free selections of RGB pins for 1bit color mode
 #define DIRECT_OUTPUT
 
-// with STM32F4 use DMA where available
-#if ((defined(__STM32F4__)) && ( defined(DIRECT_OUTPUT)))
+// with STM32F4 use DMA where available (libmaple core only; STM32duino uses bit-bang path)
+#if ((defined(__STM32F4__)) && (defined(DIRECT_OUTPUT)) && !defined(DMD_STM32DUINO))
 #define RGB_DMA
 #endif
 
@@ -31,8 +31,10 @@
 // OE PWM period in us (for Monochrome)
 #define OE_PWM_PERIOD  30
 
-// === for Monochrome SPI ===
+// Monochrome SPI DMA (libmaple core only)
+#if (defined(__STM32F1__) || defined(__STM32F4__)) && !defined(DMD_STM32DUINO)
 #define DMD_USE_DMA	1
+#endif
 
 // === for Monochrome Parallel ===
 /* Normally, CLK pin and DATA pins for all parallel matrix rows 

--- a/DMD_Defs.h
+++ b/DMD_Defs.h
@@ -1,6 +1,5 @@
 #ifndef DMD_DEFS_H_
 #define DMD_DEFS_H_
-#include "stm_int.h"
 //#define DEBUG2		1
 #define DEBUG_PRINT( x )   Serial1.print( #x );Serial1.print(" = ");Serial1.println( x )
 
@@ -14,6 +13,17 @@
 #include "WProgram.h"
 #endif
 
+#if defined(ARDUINO_ARCH_STM32)
+#include "DMD_STM32duino.h"
+#if defined(STM32F4xx) && !defined(__STM32F4__)
+#define __STM32F4__ 1
+#endif
+#if defined(STM32F1xx) && !defined(__STM32F1__)
+#define __STM32F1__ 1
+#endif
+#else
+#include "stm_int.h"
+#endif
 
 #if (defined(ARDUINO_ARCH_RP2040))
 #include <hardware/irq.h>
@@ -29,7 +39,7 @@
 #define CYCLES_PER_MICROSECOND (F_CPU / 1000000ul)
 #endif
 
-#if (defined(__STM32F1__) || defined(__STM32F4__))
+#if (defined(__STM32F1__) || defined(__STM32F4__)) && !defined(DMD_STM32DUINO)
 typedef uint32 PortType;
 #define TIM_MAX_RELOAD ((1 << 16) - 1)
 enum OE_PWM_Polarity{ OE_PWM_POSITIVE = TIMER_OC_MODE_PWM_1, OE_PWM_NEGATIVE = TIMER_OC_MODE_PWM_2 };

--- a/DMD_Multiplexer.cpp
+++ b/DMD_Multiplexer.cpp
@@ -23,6 +23,9 @@ void DMD_Multiplexer::init() {
 #endif
     for (uint8_t i = 0; i < mux_pins->count; i++) {
         pinMode(mux_pins->list[i], OUTPUT);
+#if defined(DMD_STM32DUINO)
+        dmd_set_pin_high_speed(mux_pins->list[i]);
+#endif
         digitalWrite(mux_pins->list[i], LOW);
     }
 }

--- a/DMD_RGB.cpp
+++ b/DMD_RGB.cpp
@@ -154,20 +154,7 @@ void DMD_RGB_BASE::initialize_timers(voidFuncPtr handler) {
 }
 #endif
 
-/*--------------------------------------------------------------------------------------*/
-#if (defined(__STM32F1__) || defined(__STM32F4__))
-void DMD_RGB_BASE::flushPanelShiftRegs() {
-	for (uint8_t pass = 0; pass < 4; pass++) {
-		for (uint8_t row = 0; row < nRows; row++) {
-			Mux->set_mux(row);
-			send_to_allRGB(0, 3);
-			send_to_allRGB(0, 3);
-		}
-	}
-	Mux->set_mux(0);
-}
 
-void DMD_RGB_BASE::panelResync() {
 }
 #endif
 
@@ -185,9 +172,6 @@ void DMD_RGB_BASE::init(uint16_t user_fps) {
 	set_pin_modes();
 	//generate_muxmask();
 	generate_rgbtable();
-#if defined(DMD_STM32DUINO)
-	flushPanelShiftRegs();
-#endif
 	chip_init();
 #elif (defined(ARDUINO_ARCH_RP2040))
 	// generate_muxmask();
@@ -195,11 +179,7 @@ void DMD_RGB_BASE::init(uint16_t user_fps) {
 	initialize_timers(scan_running_dmd_R);
 	setBrightness(200);
 	clearScreen(true);
-#if defined(DMD_STM32DUINO)
-	plane = 0;
-	row = 0;
-	buffptr = matrixbuff[1 - backindex];
-#endif
+
 
 }
 /*--------------------------------------------------------------------------------------*/
@@ -369,8 +349,7 @@ void DMD_RGB_BASE::scan_dmd_p1() {
 			if (swapflag == true) {    // Swap front/back buffers if requested
 				backindex = 1 - backindex;
 				swapflag = false;
-				bDMDScreenRAM = matrixbuff[backindex];
-				front_buff = matrixbuff[1 - backindex];
+				
 				}
 			}
 		buffptr = matrixbuff[1 - backindex]; // Reset into front buffer

--- a/DMD_RGB.cpp
+++ b/DMD_RGB.cpp
@@ -72,6 +72,9 @@ void DMD_RGB_BASE::generate_rgbtable_default(uint8_t options) {
 
 	for (uint8_t i = 0; i < 6; i++) {
 		pinMode(rgbpins[i], OUTPUT);
+#if defined(DMD_STM32DUINO)
+		dmd_set_pin_high_speed(rgbpins[i]);
+#endif
 		rgbmask[i] = digitalPinToBitMask(rgbpins[i]); // Pin bit mask
 		clk_clrmask |= rgbmask[i];   // Add to RGB+CLK bit mask
 		rgbmask_all |= rgbmask[i];
@@ -152,7 +155,28 @@ void DMD_RGB_BASE::initialize_timers(voidFuncPtr handler) {
 #endif
 
 /*--------------------------------------------------------------------------------------*/
+#if (defined(__STM32F1__) || defined(__STM32F4__))
+void DMD_RGB_BASE::flushPanelShiftRegs() {
+	for (uint8_t pass = 0; pass < 4; pass++) {
+		for (uint8_t row = 0; row < nRows; row++) {
+			Mux->set_mux(row);
+			send_to_allRGB(0, 3);
+			send_to_allRGB(0, 3);
+		}
+	}
+	Mux->set_mux(0);
+}
+
+void DMD_RGB_BASE::panelResync() {
+}
+#endif
+
+/*--------------------------------------------------------------------------------------*/
 void DMD_RGB_BASE::init(uint16_t user_fps) {
+
+#if defined(DMD_STM32DUINO)
+	dmd_force_timers_stop();
+#endif
 
 	if (user_fps) this->default_fps = user_fps;
 	this->setCycleLen();
@@ -161,6 +185,9 @@ void DMD_RGB_BASE::init(uint16_t user_fps) {
 	set_pin_modes();
 	//generate_muxmask();
 	generate_rgbtable();
+#if defined(DMD_STM32DUINO)
+	flushPanelShiftRegs();
+#endif
 	chip_init();
 #elif (defined(ARDUINO_ARCH_RP2040))
 	// generate_muxmask();
@@ -168,6 +195,11 @@ void DMD_RGB_BASE::init(uint16_t user_fps) {
 	initialize_timers(scan_running_dmd_R);
 	setBrightness(200);
 	clearScreen(true);
+#if defined(DMD_STM32DUINO)
+	plane = 0;
+	row = 0;
+	buffptr = matrixbuff[1 - backindex];
+#endif
 
 }
 /*--------------------------------------------------------------------------------------*/
@@ -337,6 +369,8 @@ void DMD_RGB_BASE::scan_dmd_p1() {
 			if (swapflag == true) {    // Swap front/back buffers if requested
 				backindex = 1 - backindex;
 				swapflag = false;
+				bDMDScreenRAM = matrixbuff[backindex];
+				front_buff = matrixbuff[1 - backindex];
 				}
 			}
 		buffptr = matrixbuff[1 - backindex]; // Reset into front buffer

--- a/DMD_RGB.cpp
+++ b/DMD_RGB.cpp
@@ -150,11 +150,6 @@ void DMD_RGB_BASE::initialize_timers(voidFuncPtr handler) {
 		dma_enable(rgbDmaDev, clkTxDmaStream);
 #endif
 #endif
-
-}
-#endif
-
-
 }
 #endif
 

--- a/DMD_RGB.h
+++ b/DMD_RGB.h
@@ -97,7 +97,6 @@ public:
 	}
 
 	void configure_multiplexer(MUX_TYPE mux);
-	void panelResync();
 	
 	~DMD_RGB_BASE();
 
@@ -120,7 +119,7 @@ protected:
 		
 #endif
     virtual void send_to_allRGB(uint16_t data, uint16_t latches);
-    void flushPanelShiftRegs();
+    
     virtual void chip_init() {};
 	virtual void setCycleLen();
 	virtual uint16_t get_base_addr(int16_t& x, int16_t& y);

--- a/DMD_RGB.h
+++ b/DMD_RGB.h
@@ -22,7 +22,7 @@
 #define DMD_RGB_H
 
 #include "DMD_STM32a.h"
-#if (defined(__STM32F1__))
+#if (defined(__STM32F1__) && !defined(DMD_STM32DUINO))
 #include <dma_private.h>
 #endif
 
@@ -97,6 +97,7 @@ public:
 	}
 
 	void configure_multiplexer(MUX_TYPE mux);
+	void panelResync();
 	
 	~DMD_RGB_BASE();
 
@@ -119,6 +120,7 @@ protected:
 		
 #endif
     virtual void send_to_allRGB(uint16_t data, uint16_t latches);
+    void flushPanelShiftRegs();
     virtual void chip_init() {};
 	virtual void setCycleLen();
 	virtual uint16_t get_base_addr(int16_t& x, int16_t& y);

--- a/DMD_STM32a.cpp
+++ b/DMD_STM32a.cpp
@@ -81,13 +81,22 @@ void DMD::set_pin_modes() {
 
 	digitalWrite(pin_DMD_SCLK, LOW);
 	pinMode(pin_DMD_SCLK, OUTPUT);
-#if defined(__STM32F1__) 
+#if defined(DMD_STM32DUINO)
+	oe_channel = dmd_get_oe_channel(pin_DMD_nOE);
+#elif defined(__STM32F1__) 
 	oe_channel = PIN_MAP[pin_DMD_nOE].timer_channel;
 #elif defined(__STM32F4__) 
 	oe_channel = timer_map[pin_DMD_nOE].channel;
 #endif
 
+#if defined(DMD_STM32DUINO)
+	dmd_set_pin_high_speed(pin_DMD_CLK);
+	dmd_set_pin_high_speed(pin_DMD_SCLK);
+	dmd_set_pin_high_speed(pin_DMD_nOE);
+	dmd_oe_blank_gpio(pin_DMD_nOE);
+#else
 	pinMode(pin_DMD_nOE, PWM);  // setup the pin as PWM
+#endif
 #endif
 }
 
@@ -123,6 +132,10 @@ void DMD::init(uint16_t scan_interval) {
 /*--------------------------------------------------------------------------------------*/
 #if (defined(__STM32F1__) || defined(__STM32F4__))
 void DMD::initialize_timers(voidFuncPtr handler) {
+
+#if defined(DMD_STM32DUINO)
+	dmd_init_oe_pwm(pin_DMD_nOE, oe_channel);
+#endif
 
 	if (handler != NULL) this->setup_main_timer(this->scan_cycle_len, handler);
 	uint16 prescaler = timer_get_prescaler(MAIN_TIMER) + 1;
@@ -214,6 +227,12 @@ void DMD::initialize_timers(voidFuncPtr handler) {
 #if (defined(__STM32F1__) || defined(__STM32F4__))
 uint16_t DMD::setup_main_timer(uint32_t cycles, voidFuncPtr handler) {
 
+#if defined(DMD_STM32DUINO)
+	if (handler != NULL) {
+		timer_attach_interrupt(MAIN_TIMER, TIMER_UPDATE_INTERRUPT, handler);
+	}
+#endif
+
 	timer_init(MAIN_TIMER);
 	timer_pause(MAIN_TIMER);
 	uint16 prescaler = (uint16)(cycles / TIM_MAX_RELOAD ) + 1;
@@ -221,7 +240,9 @@ uint16_t DMD::setup_main_timer(uint32_t cycles, voidFuncPtr handler) {
 	
 	timer_set_prescaler(MAIN_TIMER, prescaler - 1);
 	timer_set_reload(MAIN_TIMER, this->scan_cycle_len);
+#if !defined(DMD_STM32DUINO)
 	timer_attach_interrupt(MAIN_TIMER, TIMER_UPDATE_INTERRUPT, handler);
+#endif
 	timer_generate_update(MAIN_TIMER);
 	timer_resume(MAIN_TIMER);
 	return prescaler;

--- a/DMD_STM32duino.cpp
+++ b/DMD_STM32duino.cpp
@@ -1,0 +1,260 @@
+#include "DMD_STM32duino.h"
+
+#if defined(DMD_STM32DUINO)
+
+#include "timer.h"
+#include "stm32yyxx_ll_gpio.h"
+#include "stm32yyxx_ll_tim.h"
+
+void dmd_hw_timer_prepare(TIM_TypeDef *tim);
+
+static voidFuncPtr dmdMainHandler = nullptr;
+static HardwareTimer *dmdMainTimer = nullptr;
+static uint32_t dmdOePin = NC;
+static PinName dmdOePinName = NC;
+static uint8_t dmdOeChannel = 1;
+
+static uint32_t dmd_ll_channel(uint8_t channel) {
+  switch (channel) {
+    case 1: return LL_TIM_CHANNEL_CH1;
+    case 2: return LL_TIM_CHANNEL_CH2;
+    case 3: return LL_TIM_CHANNEL_CH3;
+    case 4: return LL_TIM_CHANNEL_CH4;
+    default: return LL_TIM_CHANNEL_CH1;
+  }
+}
+
+static TIM_TypeDef *dmd_tim(const timer_dev *dev) {
+  return (TIM_TypeDef *)dev;
+}
+
+static bool dmd_find_tim3_mapping(uint32_t pin, PinName *outPin, uint8_t *channel) {
+  PinName base = digitalPinToPinName(pin);
+  if (base == NC) {
+    return false;
+  }
+
+  const PinName variants[] = {
+    base,
+    (PinName)(base | ALT1),
+    (PinName)(base | ALT2),
+  };
+
+  for (PinName variant : variants) {
+    for (const PinMap *map = PinMap_TIM; map->pin != NC; map++) {
+      if (map->pin == variant && map->peripheral == TIM3) {
+        *outPin = variant;
+        *channel = STM_PIN_CHANNEL(map->function);
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+static void dmd_main_timer_isr(void) {
+  if (dmdMainHandler) {
+    dmdMainHandler();
+  }
+}
+
+void dmd_force_timers_stop(void) {
+  if (dmdMainTimer) {
+    dmdMainTimer->pause();
+    dmdMainTimer->detachInterrupt();
+    delete dmdMainTimer;
+    dmdMainTimer = nullptr;
+  }
+  dmd_hw_timer_prepare(TIM3);
+  dmd_hw_timer_prepare(TIM4);
+  dmdMainHandler = nullptr;
+}
+
+void dmd_set_pin_high_speed(uint32_t pin) {
+  if (!digitalPinIsValid(pin)) {
+    return;
+  }
+  PinName pn = digitalPinToPinName(pin);
+  GPIO_TypeDef *port = get_GPIO_Port(STM_PORT(pn));
+#if defined(STM32F1xx) || defined(__STM32F1__)
+  LL_GPIO_SetPinSpeed(port, STM_GPIO_PIN(pn), LL_GPIO_SPEED_FREQ_HIGH);
+#else
+  LL_GPIO_SetPinSpeed(port, STM_GPIO_PIN(pn), LL_GPIO_SPEED_FREQ_VERY_HIGH);
+#endif
+}
+
+void dmd_oe_blank_gpio(uint32_t pin) {
+  LL_TIM_DisableCounter(TIM3);
+  pinMode(pin, OUTPUT);
+  digitalWrite(pin, HIGH);
+}
+
+void dmd_hw_timer_prepare(TIM_TypeDef *tim) {
+  if (!tim) {
+    return;
+  }
+
+  timer_index_t index = get_timer_index(tim);
+  if (HardwareTimer_Handle[index] != nullptr) {
+    HardwareTimer_Handle[index] = nullptr;
+  }
+
+  if (tim == TIM3) {
+    __HAL_RCC_TIM3_FORCE_RESET();
+    __HAL_RCC_TIM3_RELEASE_RESET();
+    __HAL_RCC_TIM3_CLK_ENABLE();
+  } else if (tim == TIM4) {
+    __HAL_RCC_TIM4_FORCE_RESET();
+    __HAL_RCC_TIM4_RELEASE_RESET();
+    __HAL_RCC_TIM4_CLK_ENABLE();
+  }
+}
+
+uint8_t dmd_get_oe_channel(uint32_t pin) {
+  PinName timPin;
+  uint8_t channel;
+  if (dmd_find_tim3_mapping(pin, &timPin, &channel)) {
+    return channel;
+  }
+
+  uint32_t function = pinmap_function(digitalPinToPinName(pin), PinMap_TIM);
+  if (function == NP) {
+    return 1;
+  }
+  return STM_PIN_CHANNEL(function);
+}
+
+void dmd_init_oe_pwm(uint32_t pin, uint8_t channel) {
+  dmdOePin = pin;
+  dmdOeChannel = channel;
+
+  PinName timPin;
+  uint8_t timCh;
+  if (dmd_find_tim3_mapping(pin, &timPin, &timCh)) {
+    dmdOePinName = timPin;
+    dmdOeChannel = timCh;
+  } else {
+    dmdOePinName = digitalPinToPinName(pin);
+  }
+
+  dmd_hw_timer_prepare(TIM3);
+  pinmap_pinout(dmdOePinName, PinMap_TIM);
+
+  LL_TIM_DisableCounter(TIM3);
+  LL_TIM_SetPrescaler(TIM3, 0);
+  LL_TIM_SetAutoReload(TIM3, TIM_MAX_RELOAD);
+  LL_TIM_SetCounter(TIM3, 0);
+
+  uint32_t ll_ch = dmd_ll_channel(dmdOeChannel);
+  LL_TIM_OC_SetMode(TIM3, ll_ch, LL_TIM_OCMODE_PWM2);
+  LL_TIM_CC_EnableChannel(TIM3, ll_ch);
+  switch (dmdOeChannel) {
+    case 1: LL_TIM_OC_SetCompareCH1(TIM3, 0); break;
+    case 2: LL_TIM_OC_SetCompareCH2(TIM3, 0); break;
+    case 3: LL_TIM_OC_SetCompareCH3(TIM3, 0); break;
+    case 4: LL_TIM_OC_SetCompareCH4(TIM3, 0); break;
+  }
+}
+
+void timer_init(const timer_dev *dev) {
+  TIM_TypeDef *tim = dmd_tim(dev);
+  LL_TIM_DisableCounter(tim);
+  LL_TIM_SetCounter(tim, 0);
+}
+
+void timer_pause(const timer_dev *dev) {
+  LL_TIM_DisableCounter(dmd_tim(dev));
+}
+
+void timer_resume(const timer_dev *dev) {
+  TIM_TypeDef *tim = dmd_tim(dev);
+  if (dev == TIMER4) {
+    LL_TIM_ClearFlag_UPDATE(tim);
+    LL_TIM_EnableIT_UPDATE(tim);
+  }
+  LL_TIM_EnableCounter(tim);
+}
+
+void timer_set_prescaler(const timer_dev *dev, uint16_t prescaler) {
+  LL_TIM_SetPrescaler(dmd_tim(dev), prescaler);
+}
+
+uint16_t timer_get_prescaler(const timer_dev *dev) {
+  return LL_TIM_GetPrescaler(dmd_tim(dev));
+}
+
+void timer_set_reload(const timer_dev *dev, uint32_t reload) {
+  if (reload == 0) {
+    reload = 1;
+  }
+  LL_TIM_SetAutoReload(dmd_tim(dev), reload);
+}
+
+void timer_set_count(const timer_dev *dev, uint32_t count) {
+  LL_TIM_SetCounter(dmd_tim(dev), count);
+}
+
+void timer_generate_update(const timer_dev *dev) {
+  LL_TIM_GenerateEvent_UPDATE(dmd_tim(dev));
+}
+
+void timer_set_compare(const timer_dev *dev, uint8_t channel, uint32_t compare) {
+  TIM_TypeDef *tim = dmd_tim(dev);
+  switch (channel) {
+    case 1: LL_TIM_OC_SetCompareCH1(tim, compare); break;
+    case 2: LL_TIM_OC_SetCompareCH2(tim, compare); break;
+    case 3: LL_TIM_OC_SetCompareCH3(tim, compare); break;
+    case 4: LL_TIM_OC_SetCompareCH4(tim, compare); break;
+  }
+}
+
+void timer_oc_set_mode(const timer_dev *dev, uint8_t channel, timer_oc_mode mode, uint8_t flags) {
+  (void)flags;
+  TIM_TypeDef *tim = dmd_tim(dev);
+  uint32_t ll_ch = dmd_ll_channel(channel);
+
+  switch (mode) {
+    case TIMER_OC_MODE_PWM_1:
+      LL_TIM_OC_SetMode(tim, ll_ch, LL_TIM_OCMODE_PWM1);
+      break;
+    case TIMER_OC_MODE_PWM_2:
+      LL_TIM_OC_SetMode(tim, ll_ch, LL_TIM_OCMODE_PWM2);
+      break;
+    case TIMER_OC_MODE_FROZEN:
+    default:
+      LL_TIM_OC_SetMode(tim, ll_ch, LL_TIM_OCMODE_FROZEN);
+      break;
+  }
+  LL_TIM_CC_EnableChannel(tim, ll_ch);
+}
+
+void timer_cc_enable(const timer_dev *dev, uint8_t channel) {
+  LL_TIM_CC_EnableChannel(dmd_tim(dev), dmd_ll_channel(channel));
+}
+
+void timer_attach_interrupt(const timer_dev *dev, uint8_t type, voidFuncPtr handler) {
+  (void)type;
+  if (dev != TIMER4 || !handler) {
+    return;
+  }
+
+  dmdMainHandler = handler;
+
+  if (dmdMainTimer) {
+    dmdMainTimer->pause();
+    dmdMainTimer->detachInterrupt();
+    delete dmdMainTimer;
+    dmdMainTimer = nullptr;
+  }
+
+  timer_index_t index = get_timer_index(TIM4);
+  if (HardwareTimer_Handle[index] != nullptr) {
+    HardwareTimer_Handle[index] = nullptr;
+  }
+
+  dmdMainTimer = new HardwareTimer(TIM4);
+  dmdMainTimer->setPreloadEnable(true);
+  dmdMainTimer->attachInterrupt(dmd_main_timer_isr);
+}
+
+#endif

--- a/DMD_STM32duino.h
+++ b/DMD_STM32duino.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#if defined(ARDUINO_ARCH_STM32)
+
+#include <Arduino.h>
+#include <HardwareTimer.h>
+#include "PinNamesTypes.h"
+#include "pinmap.h"
+#include "PeripheralPins.h"
+
+#define DMD_STM32DUINO 1
+
+typedef void (*voidFuncPtr)(void);
+typedef TIM_TypeDef timer_dev;
+typedef uint32_t PortType;
+typedef uint16_t uint16;
+
+#define TIMER1 ((timer_dev *)TIM1)
+#define TIMER2 ((timer_dev *)TIM2)
+#define TIMER3 ((timer_dev *)TIM3)
+#define TIMER4 ((timer_dev *)TIM4)
+
+#define TIMER_UPDATE_INTERRUPT 0
+#define TIM_MAX_RELOAD ((1 << 16) - 1)
+
+enum timer_oc_mode {
+  TIMER_OC_MODE_PWM_1 = 0,
+  TIMER_OC_MODE_PWM_2 = 1,
+  TIMER_OC_MODE_FROZEN = 2,
+};
+
+enum OE_PWM_Polarity {
+  OE_PWM_POSITIVE = TIMER_OC_MODE_PWM_1,
+  OE_PWM_NEGATIVE = TIMER_OC_MODE_PWM_2
+};
+
+#ifdef portSetRegister
+#undef portSetRegister
+#endif
+
+static inline volatile uint32_t *dmd_portSetRegister(uint32_t pin) {
+  return &(digitalPinToPort(pin)->BSRR);
+}
+#define portSetRegister(pin) dmd_portSetRegister(pin)
+
+uint8_t dmd_get_oe_channel(uint32_t pin);
+void dmd_init_oe_pwm(uint32_t pin, uint8_t channel);
+void dmd_set_pin_high_speed(uint32_t pin);
+void dmd_oe_blank_gpio(uint32_t pin);
+void dmd_hw_timer_prepare(TIM_TypeDef *tim);
+void dmd_force_timers_stop(void);
+
+void timer_init(const timer_dev *dev);
+void timer_pause(const timer_dev *dev);
+void timer_resume(const timer_dev *dev);
+void timer_set_prescaler(const timer_dev *dev, uint16_t prescaler);
+uint16_t timer_get_prescaler(const timer_dev *dev);
+void timer_set_reload(const timer_dev *dev, uint32_t reload);
+void timer_set_count(const timer_dev *dev, uint32_t count);
+void timer_generate_update(const timer_dev *dev);
+void timer_set_compare(const timer_dev *dev, uint8_t channel, uint32_t compare);
+void timer_oc_set_mode(const timer_dev *dev, uint8_t channel, timer_oc_mode mode, uint8_t flags);
+void timer_cc_enable(const timer_dev *dev, uint8_t channel);
+void timer_attach_interrupt(const timer_dev *dev, uint8_t type, voidFuncPtr handler);
+
+#endif

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Other features
 Compatible boards
 -----------------
 
-* STM32F1 - STM32F103C8 (bluepill) and STM32F103C6 boards tested 
-* STM32F4 - STM32F401CC and STM32F411CE boards 
+* STM32F1 — STM32F103C8/C6 (Roger Clark); STM32F103CBT (STM32duino, verified)
+* STM32F4 — STM32F401CC, STM32F411CE (Roger Clark and STM32duino, verified)
 * Raspberry Pi Pico and other RP2040-based boards. 
 * RP2350 based boards should works as well, but not fully tested yet.
 
@@ -90,12 +90,22 @@ There are two ways to install the library:
    
 #### Arduino support packages for STM32 and Raspberry Pi Pico
 
-* STM32
+* STM32 — two cores, selected automatically at compile time:
 
-    The only Roger Clarks's repo https://github.com/rogerclarkmelbourne/Arduino_STM32 is supported for STM32 based boards on Arduino IDE.
-  
-  > Please note that Clark's repo versions prior [d05a128](https://github.com/rogerclarkmelbourne/Arduino_STM32/commit/d05a1289f1e2eaa5127a4bfed9602e2cd48c6ffe) (28 Apr 2024) is incompatible with recent Adafruit GFX library. Use Adafruit GFX version prior to 1.8.0 (v1.7.0 is OK) https://github.com/adafruit/Adafruit-GFX-Library/releases/tag/1.7.0
+  | Core | Arduino package | When active |
+  |------|-----------------|-------------|
+  | **Roger Clark (libmaple)** | [Arduino_STM32](https://github.com/rogerclarkmelbourne/Arduino_STM32) | `__STM32F1__` / `__STM32F4__`, without `ARDUINO_ARCH_STM32` |
+  | **STM32duino** | [Arduino Core STM32](https://github.com/stm32duino/Arduino_Core_STM32) | `ARDUINO_ARCH_STM32` → `DMD_STM32DUINO` |
 
+  Roger Clark uses the original path (`stm_int.h`, libmaple timers/GPIO). STM32duino uses a compatibility layer (`DMD_STM32duino.h` / `DMD_STM32duino.cpp`). Paths are split with `#if defined(DMD_STM32DUINO)`; building for one core does not replace the other.
+
+  Upstream [board707/DMD_STM32](https://github.com/board707/DMD_STM32) documents Roger Clark only. STM32duino support is present in this tree as an additional port.
+
+  > Roger Clark: core versions before [d05a128](https://github.com/rogerclarkmelbourne/Arduino_STM32/commit/d05a1289f1e2eaa5127a4bfed9602e2cd48c6ffe) (28 Apr 2024) are incompatible with recent Adafruit GFX. Use core ≥ d05a128 or Adafruit GFX ≤ 1.7.0 ([v1.7.0](https://github.com/adafruit/Adafruit-GFX-Library/releases/tag/1.7.0)).
+
+  > STM32duino: RGB DMA and Monochrome SPI DMA are disabled; RGB uses bit-bang, Monochrome SPI uses polling. OE PWM via `DMD_STM32duino` shim.
+
+  **STM32duino port verified on:** STM32F103 (CBT), STM32F401, STM32F411 — RGB panels (`DMD_RGB`), dual buffer, GFX/Cyrillic fonts. Example: `examples/STM32duino/dmd_rgb_effects`.
 
 * Raspberry Pi Pico/ Pico2
 

--- a/examples/STM32duino/dmd_rgb_effects/dmd_rgb_effects.ino
+++ b/examples/STM32duino/dmd_rgb_effects/dmd_rgb_effects.ino
@@ -1,0 +1,542 @@
+/*--------------------------------------------------------------------------------------
+  RGB effects demo for STM32duino (Arduino Core STM32)
+
+  Panel: RGB40x20_S5_LNikon (pattern 102), 1x1, COLOR_4BITS, dual buffer.
+  Fonts: GlametrixBold9pt / GlametrixLight12pt with Cyrillic (utf8_rus + drawMarqueeX).
+
+  Tested: STM32F103CBT, STM32F401, STM32F411.
+  Serial 115200 — scene names in loop.
+ ------------------------------------------------------------------------------------- */
+#include "DMD_RGB.h"
+#pragma GCC diagnostic ignored "-Wnarrowing"
+#pragma GCC diagnostic ignored "-Woverflow"
+#include "gfx_fonts/GlametrixBold9pt7b.h"
+#include "gfx_fonts/GlametrixLight12pt7b.h"
+#pragma GCC diagnostic warning "-Wnarrowing"
+#pragma GCC diagnostic warning "-Woverflow"
+
+#define DISPLAYS_ACROSS 1
+#define DISPLAYS_DOWN 1
+#define ENABLE_DUAL_BUFFER true
+#define SCROLL_SCENE_MS 12000
+
+#define DMD_PIN_A PB6
+#define DMD_PIN_B PB5
+#define DMD_PIN_C PB4
+#define DMD_PIN_D PB3
+#define DMD_PIN_E PB8
+uint8_t mux_list[] = { DMD_PIN_A, DMD_PIN_B, DMD_PIN_C, DMD_PIN_D, DMD_PIN_E };
+
+#define DMD_PIN_nOE PB0
+#define DMD_PIN_SCLK PB7
+uint8_t custom_rgbpins[] = { PA6, PA0, PA1, PA2, PA3, PA4, PA5 };
+
+DMD_RGB<RGB40x20_S5_LNikon, COLOR_4BITS> dmd(
+  mux_list, DMD_PIN_nOE, DMD_PIN_SCLK, custom_rgbpins,
+  DISPLAYS_ACROSS, DISPLAYS_DOWN, ENABLE_DUAL_BUFFER);
+
+DMD_GFX_Font FontSmall((uint8_t*)&GlametrixBold9pt7b, (uint8_t*)&GlametrixBold9pt8b_rus, 0x80, 11);
+DMD_GFX_Font FontBig((uint8_t*)&GlametrixLight12pt7b, (uint8_t*)&GlametrixLight12pt8b_rus, 0x80, 13);
+
+#define BLUE_LED_PIN PC13
+#define BRIGHTNESS 200
+#define SCROLL_MS 50
+
+static DMD_Font* activeFont = &FontSmall;
+
+static const uint16_t COL_BLACK = 0;
+static uint16_t colRed, colGreen, colBlue, colYellow, colCyan, colMagenta, colWhite;
+static uint16_t palette[6];
+
+static int textCenterY() {
+  return (dmd.height() - activeFont->get_height()) / 2;
+}
+
+static int utf8_rus(char* dest, const unsigned char* src) {
+  uint16_t i, j;
+  for (i = 0, j = 0; src[i]; i++) {
+    if ((src[i] == 0xD0) && src[i + 1]) { dest[j++] = src[++i] - 0x10; }
+    else if ((src[i] == 0xD1) && src[i + 1]) { dest[j++] = src[++i] + 0x30; }
+    else dest[j++] = src[i];
+  }
+  dest[j] = '\0';
+  return j;
+}
+
+static void matrixPinsSafeBeforeInit() {
+  pinMode(DMD_PIN_nOE, OUTPUT);
+  digitalWrite(DMD_PIN_nOE, HIGH);
+  pinMode(DMD_PIN_SCLK, OUTPUT);
+  digitalWrite(DMD_PIN_SCLK, LOW);
+}
+
+static void initColors() {
+  colRed     = dmd.Color888(255, 0, 0);
+  colGreen   = dmd.Color888(0, 255, 0);
+  colBlue    = dmd.Color888(0, 0, 255);
+  colYellow  = dmd.Color888(255, 255, 0);
+  colCyan    = dmd.Color888(0, 255, 255);
+  colMagenta = dmd.Color888(255, 0, 255);
+  colWhite   = dmd.Color888(255, 255, 255);
+  palette[0] = colRed;
+  palette[1] = colGreen;
+  palette[2] = colBlue;
+  palette[3] = colYellow;
+  palette[4] = colCyan;
+  palette[5] = colMagenta;
+}
+
+static uint32_t lastTick = 0;
+static uint32_t sceneStart = 0;
+
+static void selectFont(DMD_Font* font) {
+  activeFont = font;
+  dmd.selectFont(font);
+}
+
+static void finishFrame(bool copyFromFront = true) {
+  dmd.swapBuffers(copyFromFront);
+}
+
+static void showFrame(bool copyFromFront = true) {
+  finishFrame(copyFromFront);
+}
+
+static int scrollTextY() {
+  return (dmd.height() > 16) ? 2 : 0;
+}
+
+static const char rusPrivet[] = "Привет!";
+
+static void drawRusMarquee(const char* rusText, int x, int y, uint16_t fg) {
+  dmd.setTextColor(fg, COL_BLACK);
+  dmd.drawMarqueeX(rusText, x, y);
+}
+
+enum Scene : uint8_t {
+  SCENE_TITLE = 0,
+  SCENE_FONT_SHOW,
+  SCENE_SCROLL_H,
+  SCENE_BRIGHTNESS,
+  SCENE_SCROLL_V,
+  SCENE_VSCROLL_GLYPH,
+  SCENE_MULTICOLOR,
+  SCENE_COLOR_WIPE,
+  SCENE_PIXELS,
+  SCENE_COUNT
+};
+
+static uint8_t scene = SCENE_TITLE;
+static uint8_t phase = 0;
+static uint8_t colorIdx = 0;
+static uint8_t stepIdx = 0;
+static uint8_t brightnessVal = 80;
+
+static const int8_t hSteps[] = { 1, -1, -2, 2 };
+static const int8_t vSteps[] = { 1, -1, -2, 2 };
+
+static void showSceneName(const char* name) {
+  Serial.print(F("scene: "));
+  Serial.println(name);
+}
+
+static void prepMarquee(uint16_t fg) {
+  dmd.setMarqueeColor(fg, COL_BLACK);
+}
+
+static void beginScene(uint8_t next) {
+  scene = next;
+  phase = 0;
+  colorIdx = 0;
+  stepIdx = 0;
+  sceneStart = millis();
+  prepMarquee(COL_BLACK);
+  dmd.fillScreen(COL_BLACK);
+  dmd.setBrightness(BRIGHTNESS);
+  selectFont(&FontSmall);
+  showFrame();
+}
+
+static void nextScene() {
+  beginScene((scene + 1) % SCENE_COUNT);
+}
+
+static void runTitle() {
+  const char* msg = "RGB";
+
+  if (phase == 0) {
+    showSceneName("title (GlametrixLight12)");
+    selectFont(&FontBig);
+    dmd.setTextColor(palette[0], COL_BLACK);
+    phase = 1;
+    lastTick = millis();
+  }
+
+  if (millis() - lastTick >= 450) {
+    lastTick = millis();
+    colorIdx = (colorIdx + 1) % 6;
+    dmd.fillScreen(COL_BLACK);
+    dmd.setTextColor(palette[colorIdx], COL_BLACK);
+    int x = (dmd.width() - dmd.stringWidth(msg)) / 2;
+    dmd.drawStringX(x, textCenterY(), msg, palette[colorIdx]);
+    showFrame();
+    if (colorIdx == 0 && millis() - sceneStart > 3000) {
+      nextScene();
+    }
+  }
+}
+
+static void runFontShow() {
+  static const char* smallMsg = "Bold 9pt";
+  static const char* bigMsg = "BIG";
+  static char rusBuf[32];
+
+  if (phase == 0) {
+    showSceneName("fonts compare");
+    utf8_rus(rusBuf, (const unsigned char*)rusPrivet);
+    phase = 1;
+    lastTick = millis();
+    colorIdx = 0;
+  }
+
+  if (millis() - lastTick < 900) return;
+  lastTick = millis();
+
+  dmd.fillScreen(COL_BLACK);
+  if (colorIdx == 6) {
+    selectFont(&FontSmall);
+    int x = (dmd.width() - dmd.stringWidth(rusBuf)) / 2;
+    drawRusMarquee(rusBuf, x, textCenterY(), colYellow);
+  } else if (colorIdx % 2 == 0) {
+    selectFont(&FontSmall);
+    dmd.drawStringX(2, 2, smallMsg, palette[colorIdx % 6]);
+  } else {
+    selectFont(&FontBig);
+    int x = (dmd.width() - dmd.stringWidth(bigMsg)) / 2;
+    dmd.drawStringX(x, textCenterY(), bigMsg, palette[colorIdx % 6]);
+  }
+  showFrame();
+  colorIdx++;
+  if (colorIdx >= 7) {
+    nextScene();
+  }
+}
+
+static int16_t scrollHStartX(const char* msg, int8_t step) {
+  int16_t w = dmd.stringWidth(msg);
+  if (step < 0) {
+    return dmd.width() - w;
+  }
+  return -w;
+}
+
+static void runScrollH() {
+  static const char* msgs[] = {
+    ">>> RIGHT >>>",
+    "<<< LEFT  <<<",
+    "== FAST ==",
+    "DMD_STM32"
+  };
+  static int16_t scrollX = 0;
+  static const uint32_t MSG_MS = 3000;
+
+  if (phase == 0) {
+    showSceneName("scroll H (GlametrixBold9)");
+    selectFont(&FontSmall);
+    stepIdx = 0;
+    colorIdx = 0;
+    scrollX = scrollHStartX(msgs[0], hSteps[0]);
+    phase = 1;
+    lastTick = millis() - SCROLL_MS;
+    sceneStart = millis();
+    dmd.clearScreen(true);
+    prepMarquee(palette[colorIdx]);
+    dmd.drawMarqueeX(msgs[0], scrollX, scrollTextY());
+    showFrame(false);
+    return;
+  }
+
+  uint8_t msgIdx = (uint8_t)(((millis() - sceneStart) / MSG_MS) % 4);
+  if (msgIdx != stepIdx) {
+    stepIdx = msgIdx;
+    colorIdx = stepIdx % 6;
+    scrollX = scrollHStartX(msgs[stepIdx], hSteps[stepIdx]);
+    lastTick = millis() - SCROLL_MS;
+  }
+
+  if (millis() - lastTick < SCROLL_MS) return;
+  lastTick = millis();
+
+  const char* msg = msgs[stepIdx];
+  int8_t step = hSteps[stepIdx];
+  int16_t msgW = dmd.stringWidth(msg);
+
+  scrollX += step;
+
+  if (step > 0 && scrollX > dmd.width()) {
+    scrollX = -msgW;
+  } else if (step < 0 && scrollX + msgW <= 0) {
+    scrollX = dmd.width() - msgW;
+  }
+
+  dmd.clearScreen(true);
+  prepMarquee(palette[colorIdx]);
+  dmd.drawMarqueeX(msg, scrollX, scrollTextY());
+  showFrame(false);
+
+  if (millis() - sceneStart >= SCROLL_SCENE_MS) {
+    nextScene();
+  }
+}
+
+static void runBrightness() {
+  const char* msg = "BRIGHT";
+
+  if (phase == 0) {
+    showSceneName("brightness");
+    selectFont(&FontSmall);
+    dmd.setTextColor(colWhite, COL_BLACK);
+    int x = (dmd.width() - dmd.stringWidth(msg)) / 2;
+    dmd.drawStringX(x, textCenterY(), msg, colWhite);
+    showFrame();
+    brightnessVal = 40;
+    phase = 1;
+    lastTick = millis();
+  }
+
+  if (millis() - lastTick < 30) return;
+  lastTick = millis();
+
+  if (phase == 1) {
+    brightnessVal += 4;
+    dmd.setBrightness(brightnessVal);
+    if (brightnessVal >= 250) phase = 2;
+  } else {
+    brightnessVal -= 4;
+    dmd.setBrightness(brightnessVal);
+    if (brightnessVal <= 40) nextScene();
+  }
+}
+
+static void runScrollV() {
+  static const char* msg = "UP/DOWN";
+
+  if (phase == 0) {
+    showSceneName("scroll V (GlametrixBold9)");
+    selectFont(&FontSmall);
+    stepIdx = 0;
+    colorIdx = 0;
+    prepMarquee(colCyan);
+    dmd.fillScreen(COL_BLACK);
+    dmd.drawMarqueeX(msg, 2, 0);
+    showFrame();
+    phase = 1;
+    lastTick = millis();
+    sceneStart = millis();
+    return;
+  }
+
+  if (millis() - lastTick < SCROLL_MS) return;
+  lastTick = millis();
+
+  if (dmd.stepMarquee(0, vSteps[stepIdx]) & 1) {
+    colorIdx = (colorIdx + 1) % 6;
+    prepMarquee(palette[colorIdx]);
+    stepIdx = (stepIdx + 1) % 4;
+    if (vSteps[stepIdx] < 0) {
+      dmd.drawMarqueeX(msg, 2, dmd.height());
+    } else {
+      dmd.drawMarqueeX(msg, 2, 0);
+    }
+  }
+  showFrame();
+
+  if (millis() - sceneStart >= SCROLL_SCENE_MS) {
+    nextScene();
+  }
+}
+
+static void runVScrollGlyph() {
+  static char rusBuf[32];
+
+  if (phase == 0) {
+    showSceneName("scroll RU (GlametrixBold9)");
+    selectFont(&FontSmall);
+    utf8_rus(rusBuf, (const unsigned char*)rusPrivet);
+    dmd.fillScreen(COL_BLACK);
+    int x = (dmd.width() - dmd.stringWidth(rusBuf)) / 2;
+    drawRusMarquee(rusBuf, x, textCenterY(), colYellow);
+    showFrame();
+    phase = 1;
+    lastTick = millis();
+    sceneStart = millis();
+    return;
+  }
+
+  if (phase == 1) {
+    if (millis() - sceneStart < 2500) return;
+    prepMarquee(colGreen);
+    dmd.fillScreen(COL_BLACK);
+    dmd.setTextColor(colGreen, COL_BLACK);
+    dmd.drawMarqueeX(rusBuf, -dmd.stringWidth(rusBuf), scrollTextY());
+    showFrame();
+    phase = 2;
+    lastTick = millis();
+    sceneStart = millis();
+    return;
+  }
+
+  if (millis() - lastTick < SCROLL_MS) return;
+  lastTick = millis();
+
+  dmd.stepMarquee(1, 0);
+  showFrame();
+
+  if (millis() - sceneStart >= SCROLL_SCENE_MS) {
+    nextScene();
+  }
+}
+
+static void runMulticolor() {
+  static const char scrollMsg[] = "RGB TEST";
+  static const char fixedMsg[] = "2026";
+  static uint16_t mcColors[4];
+  static DMD_Colorlist multi(4, mcColors);
+
+  if (phase == 0) {
+    showSceneName("multicolor");
+    selectFont(&FontSmall);
+    mcColors[0] = COL_BLACK;
+    mcColors[1] = colRed;
+    mcColors[2] = colGreen;
+    mcColors[3] = colBlue;
+    dmd.setMarqueeColor(&multi);
+    dmd.fillScreen(COL_BLACK);
+    dmd.drawMarqueeX(scrollMsg, -dmd.stringWidth(scrollMsg), 0);
+    showFrame();
+    phase = 1;
+    lastTick = millis();
+    sceneStart = millis();
+    return;
+  }
+
+  if (millis() - lastTick < SCROLL_MS) return;
+  lastTick = millis();
+
+  dmd.stepMarquee(1, 0);
+  int fx = (dmd.width() - dmd.stringWidth(fixedMsg)) / 2;
+  dmd.drawStringX(fx, dmd.height() - activeFont->get_height(), fixedMsg, colYellow);
+  showFrame();
+
+  if (millis() - sceneStart > 6000) {
+    prepMarquee(colWhite);
+    nextScene();
+  }
+}
+
+static void runColorWipe() {
+  if (phase == 0) {
+    showSceneName("color wipe");
+    colorIdx = 0;
+    phase = 1;
+    lastTick = millis();
+  }
+
+  if (millis() - lastTick < 350) return;
+  lastTick = millis();
+
+  dmd.fillScreen(palette[colorIdx]);
+  showFrame();
+  colorIdx++;
+  if (colorIdx >= 6) {
+    dmd.fillScreen(COL_BLACK);
+    showFrame();
+    nextScene();
+  }
+}
+
+static void runPixels() {
+  static char rusBuf[24];
+  static bool rusReady = false;
+  static int px = 0;
+  static int py = 0;
+
+  if (phase == 0) {
+    showSceneName("pixels + cyr");
+    if (!rusReady) {
+      utf8_rus(rusBuf, (const unsigned char*)rusPrivet);
+      rusReady = true;
+    }
+    dmd.fillScreen(COL_BLACK);
+    px = 0;
+    py = 0;
+    phase = 1;
+    lastTick = millis();
+  }
+
+  if (phase == 1) {
+    if (millis() - lastTick < 6) return;
+    lastTick = millis();
+
+    dmd.drawPixel(px, py, palette[(px + py) % 6]);
+    if ((px & 7) == 7) {
+      showFrame();
+    }
+    px++;
+    if (px >= dmd.width()) {
+      px = 0;
+      py++;
+    }
+    if (py >= dmd.height()) {
+      phase = 2;
+      dmd.fillScreen(COL_BLACK);
+      selectFont(&FontSmall);
+      int x = (dmd.width() - dmd.stringWidth(rusBuf)) / 2;
+      drawRusMarquee(rusBuf, x, textCenterY(), colGreen);
+      showFrame();
+      sceneStart = millis();
+    }
+    return;
+  }
+
+  if (millis() - sceneStart > 2500) {
+    rusReady = false;
+    nextScene();
+  }
+}
+
+void setup() {
+  pinMode(BLUE_LED_PIN, OUTPUT);
+  digitalWrite(BLUE_LED_PIN, HIGH);
+
+  Serial.begin(115200);
+  Serial.println(F("DMD RGB effects demo"));
+
+  matrixPinsSafeBeforeInit();
+  dmd.init();
+  initColors();
+  dmd.setBrightness(BRIGHTNESS);
+  beginScene(SCENE_TITLE);
+  Serial.println(F("ready"));
+}
+
+void loop() {
+  switch (scene) {
+    case SCENE_TITLE:        runTitle();        break;
+    case SCENE_FONT_SHOW:    runFontShow();     break;
+    case SCENE_SCROLL_H:     runScrollH();      break;
+    case SCENE_BRIGHTNESS:   runBrightness();   break;
+    case SCENE_SCROLL_V:     runScrollV();      break;
+    case SCENE_VSCROLL_GLYPH: runVScrollGlyph(); break;
+    case SCENE_MULTICOLOR:   runMulticolor();   break;
+    case SCENE_COLOR_WIPE:   runColorWipe();    break;
+    case SCENE_PIXELS:       runPixels();       break;
+    default:                 beginScene(0);     break;
+  }
+
+  static uint32_t ledTick = 0;
+  if (millis() - ledTick >= 500) {
+    ledTick = millis();
+    digitalWrite(BLUE_LED_PIN, !digitalRead(BLUE_LED_PIN));
+  }
+}

--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=STM32 library for led matrix panels
 paragraph=Supports RGB (HUB75), Monochrome (HUB12) and Two-color (HUB08) modules
 category=Display
 url=https://github.com/board707/DMD_STM32/
-architectures=STM32F1,STM32F4,rp2040
+architectures=STM32F1,STM32F4,stm32,rp2040
 depends=Adafruit GFX Library

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=DMD_STM32
-version=1.2.11
+version=1.2.12
 author=Board707
 maintainer=Board707
 sentence=STM32 library for led matrix panels

--- a/stm_int.h
+++ b/stm_int.h
@@ -1,13 +1,13 @@
 #pragma once
-// STM integer types
-#if (defined(__STM32F1__)|| defined(__STM32F4__))
+// STM integer types (Roger Clark libmaple core only)
+#if (defined(__STM32F1__) || defined(__STM32F4__)) && !defined(DMD_STM32DUINO)
 #define uint8_t uint8
 #define byte uint8
 #define uint16_t uint16
 #define int8_t int8
 #define int16_t int16 
 #endif
-#if defined(__STM32F1__) 
+#if defined(__STM32F1__) && !defined(DMD_STM32DUINO)
 #define uint32_t uint32
 #endif
 


### PR DESCRIPTION
## Summary

Adds optional support for the official [Arduino Core STM32](https://github.com/stm32duino/Arduino_Core_STM32) (STM32duino) **in the same branch** as the existing Roger Clark (libmaple) core. The active core is selected at compile time:

| Core | Detection | Code path |
|------|-----------|-----------|
| Roger Clark | `__STM32F1__` / `__STM32F4__`, no `ARDUINO_ARCH_STM32` | Existing `stm_int.h`, DMA per `DMD_Config.h` |
| STM32duino | `ARDUINO_ARCH_STM32` → `DMD_STM32DUINO` | New `DMD_STM32duino.h` / `DMD_STM32duino.cpp` shim |

No replacement of libmaple code — only `#if defined(DMD_STM32DUINO)` branches.

## Scope (this PR)

- **Tested:** `DMD_RGB` on STM32F103 (CBT), STM32F401, STM32F411 — dual buffer, Adafruit GFX, Cyrillic fonts
- **Example:** `examples/STM32duino/dmd_rgb_effects`
- **Docs:** README (dual-core install notes), CHANGES.txt 1.2.12
- **`library.properties`:** `architectures` includes `stm32`

## STM32duino limitations (by design)

- **RGB DMA (F4):** disabled → RGB bit-bang (same as F103 on Roger Clark for RGB)
- **Monochrome SPI DMA:** disabled → polling (`scanDisplayBySPI`)
- **OE PWM:** TIM3 via compatibility shim
- **Not ported / not tested on STM32duino:** Monochrome, Parallel, SPWM — Roger Clark remains recommended for those modes and for maximum bus throughput (DMA)

## Files

- New: `DMD_STM32duino.h`, `DMD_STM32duino.cpp`, `examples/STM32duino/dmd_rgb_effects/`
- Touched: `DMD_Defs.h`, `DMD_Config.h`, `DMD_RGB.*`, `DMD_STM32a.cpp`, `DMD_Multiplexer.cpp`, `stm_int.h`, `README.md`, `CHANGES.txt`, `library.properties`

## Test plan

- [ ] Build Roger Clark example (e.g. `examples/STM32F1/dmd_rgb`) — no regressions
- [ ] Build `examples/STM32duino/dmd_rgb_effects` on STM32F103 / F401 / F411 with Arduino Core STM32
- [ ] Verify dual-buffer swap, scrolling text, brightness
- [ ] Confirm `RGB_DMA` / `DMD_USE_DMA` still enabled on Roger Clark F4 when configured
